### PR TITLE
Fix: AttributeError on FreeBSD where errno.ETIME doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Healthcheck Changelog
 ### Next Release
-* Fix comaptibility issue with FreeBSD
+* Fix compatibility issue with FreeBSD
 
 ### 1.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Healthcheck Changelog
+### Next Release
+* Fix comaptibility issue with FreeBSD
 
 ### 1.7.1
 

--- a/healthcheck/timeout.py
+++ b/healthcheck/timeout.py
@@ -10,7 +10,14 @@ class TimeoutError(Exception):
     pass
 
 
-def timeout(seconds=2, error_message=os.strerror(errno.ETIME)):
+try:
+    err_msg = os.strerror(errno.ETIME)
+except AttributeError:
+    # errno.ETIME does not exist on FreeBSD
+    err_msg = "Timer expired"
+
+
+def timeout(seconds=2, error_message=err_msg):
     def decorator(func):
         def _handle_timeout(signum, frame):
             raise TimeoutError(error_message)

--- a/healthcheck/timeout.py
+++ b/healthcheck/timeout.py
@@ -10,14 +10,8 @@ class TimeoutError(Exception):
     pass
 
 
-try:
-    err_msg = os.strerror(errno.ETIME)
-except AttributeError:
-    # errno.ETIME does not exist on FreeBSD
-    err_msg = "Timer expired"
-
-
-def timeout(seconds=2, error_message=err_msg):
+def timeout(seconds=2, error_message=os.strerror(
+        getattr(errno, 'ETIME', errno.ETIMEDOUT))):
     def decorator(func):
         def _handle_timeout(signum, frame):
             raise TimeoutError(error_message)


### PR DESCRIPTION
errno.ETIME does not exist on FreeBSD, causing AttributeError exception.

Available errno codes on FreeBSD:
https://www.freebsd.org/cgi/man.cgi?query=errno&apropos=0&sektion=0&manpath=FreeBSD+12-current&arch=default&format=html