### PR TITLE
fix: Add custom sections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -278,6 +278,12 @@ your own. Here's an example of how this would be used:
     envdump = EnvironmentDump()
     envdump.add_section("application", application_data)
 
+    # Alternative - Add sections upon initialization
+    sections = {
+        'application': application_data,
+    }
+    envdump = EnvironmentDump(sections=sections)
+
 
 Credits
 -------

--- a/healthcheck/environmentdump.py
+++ b/healthcheck/environmentdump.py
@@ -24,8 +24,12 @@ class EnvironmentDump(object):
 
         # adds custom_sections on signature
         for k, v in kwargs.items():
-            for name, func in v.items():
-                self.add_section(name, func)
+            if hasattr(v, '__call__'):
+                self.add_section(k, v)
+
+            if isinstance(v, (dict)):
+                for name, func in v.items():
+                    self.add_section(name, func)
 
     def add_section(self, name, func):
         if name in self.functions:

--- a/healthcheck/environmentdump.py
+++ b/healthcheck/environmentdump.py
@@ -22,8 +22,10 @@ class EnvironmentDump(object):
         if include_process:
             self.functions['process'] = self.get_process
 
-        # ads custom_sections on signature
-        [self.add_section(k, v) for k, v in kwargs.items() if k not in self.functions]
+        # adds custom_sections on signature
+        for k, v in kwargs.items():
+            for name, func in v.items():
+                self.add_section(name, func)
 
     def add_section(self, name, func):
         if name in self.functions:

--- a/tests/unit/test_environmentdump.py
+++ b/tests/unit/test_environmentdump.py
@@ -32,6 +32,21 @@ class BasicEnvironmentDumpTest(unittest.TestCase):
         jr = json.loads(message)
         self.assertEqual("My custom section", jr["custom_section"])
 
+    def test_custom_section_multiple(self):
+        def custom_section():
+            return "My custom section"
+
+        sections = {
+            'custom_section': custom_section,
+        }
+
+        ed = EnvironmentDump(sections=sections)
+
+        message, status, headers = ed.run()
+
+        jr = json.loads(message)
+        self.assertEqual("My custom section", jr["custom_section"])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should allow functions to be added upon class initialization
properly and become available when accessing the endpoint.

An example usage, which allows things to work as expected:
```
from flask import Flask
from healthcheck import EnvironmentDump

app = Flask(__name__)

def application_data():
    return {"maintainer": "Luis Fernando Gomes",
            "git_repo": "https://github.com/ateliedocodigo/py-healthcheck"}

def foo_data():
    return {'foo': 'bar'}

sections = {
    'application': application_data,
    'foo': foo_data,
}
envdump = EnvironmentDump(sections=sections)
app.add_url_rule("/environment", "environment", view_func=lambda: envdump.run())
app.run()
```

These changes would also allow something like this to work too
```
...
other_checks = {
    'test': lambda: 'yikes',
}
envdump = EnvironmentDump(sections=sections, additional_checks=other_checks)
app.run()
```