### PR TITLE
Setup GitHub Action for Unittests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -2,12 +2,13 @@ name: "Unittests"
 
 on: [push]
 jobs:
-  pytest:
+  tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.9]
         os: [ubuntu-latest]
+        framework: [flask, tornado]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -18,9 +19,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-      - name: Run the Flask Unit Tests via Tox
+      - name: Run the ${{framework}} Unit Tests via Tox
         run: |
-          tox -e flask
-      - name: Run the Tornado Unit Tests via Tox
-        run: |
-          tox -e tornado
+          tox -e ${{framework}}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,26 @@
+name: "Unittests"
+
+on: [push]
+jobs:
+  pytest:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.9]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Run the Flask Unit Tests via Tox
+        run: |
+          tox -e flask
+      - name: Run the Tornado Unit Tests via Tox
+        run: |
+          tox -e tornado

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,6 +1,6 @@
 name: "Unittests"
 
-on: [push]
+on: [push, pull_request]
 jobs:
   tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,6 +19,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-      - name: Run the ${{framework}} Unit Tests via Tox
+      - name: Run the ${{ matrix.framework }} Unit Tests via Tox
         run: |
-          tox -e ${{framework}}
+          tox -e ${{ matrix.framework }}


### PR DESCRIPTION
I added a .yml file that sets up a Github Action to run the unittests on each push and pull request. Using this action you could enforce passing tests in the repo settings.

See https://github.com/hf-kklein/py-healthcheck/tree/setup_github_actions_for_unittests <-- for details 
![grafik](https://user-images.githubusercontent.com/23094997/124559851-70fd8900-de3c-11eb-8d51-89cb4f38a800.png)
(the tests are not automatically run on PRs originating from forks)